### PR TITLE
boards: arm: stm32_min_dev: Add ADC_1 device

### DIFF
--- a/boards/arm/stm32_min_dev/doc/index.rst
+++ b/boards/arm/stm32_min_dev/doc/index.rst
@@ -116,6 +116,8 @@ The stm32_min_dev board configuration supports the following hardware features:
 +-----------+------------+----------------------+
 | USB       | on-chip    | USB device           |
 +-----------+------------+----------------------+
+| ADC       | on-chip    | adc                  |
++-----------+------------+----------------------+
 
 Other hardware features are not supported by the Zephyr kernel.
 
@@ -134,6 +136,7 @@ Default Zephyr Peripheral Mapping:
 - SPI_1 NSS_OE/SCK/MISO/MOSI: PA4/PA5/PA6/PA7
 - SPI_2 NSS_OE/SCK/MISO/MOSI: PB12/PB13/PB14/PB15
 - USB_DC DM/DP: PA11/PA12
+- ADC_1: PA0
 
 System Clock
 ------------

--- a/boards/arm/stm32_min_dev/pinmux.c
+++ b/boards/arm/stm32_min_dev/pinmux.c
@@ -57,6 +57,9 @@ static const struct pin_config pinconf[] = {
 	{STM32_PIN_PA11, STM32F1_PINMUX_FUNC_PA11_USB_DM},
 	{STM32_PIN_PA12, STM32F1_PINMUX_FUNC_PA12_USB_DP},
 #endif /* CONFIG_USB_DC_STM32 */
+#ifdef CONFIG_ADC_1
+	{STM32_PIN_PA0, STM32F1_PINMUX_FUNC_PA0_ADC123_IN0},
+#endif /* CONFIG_ADC_1 */
 };
 
 static int pinmux_stm32_init(struct device *port)

--- a/boards/arm/stm32_min_dev/stm32_min_dev.dtsi
+++ b/boards/arm/stm32_min_dev/stm32_min_dev.dtsi
@@ -75,3 +75,7 @@
 &usb {
 	status = "okay";
 };
+
+&adc1 {
+	status = "okay";
+};

--- a/boards/arm/stm32_min_dev/stm32_min_dev_black.yaml
+++ b/boards/arm/stm32_min_dev/stm32_min_dev_black.yaml
@@ -11,3 +11,4 @@ supported:
   - i2c
   - pwm
   - spi
+  - adc

--- a/boards/arm/stm32_min_dev/stm32_min_dev_blue.yaml
+++ b/boards/arm/stm32_min_dev/stm32_min_dev_blue.yaml
@@ -11,3 +11,4 @@ supported:
   - i2c
   - pwm
   - spi
+  - adc


### PR DESCRIPTION
Added support for ADC_1.

Signed-off-by: Ioannis Konstantelias <ikonstadel@gmail.com>